### PR TITLE
Unify datetime.tzinfo behaviour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        marshmallow: ["marshmallow>=2,<3", "marshmallow>=3,<4"]
+        marshmallow: ["marshmallow>=2,<3", "marshmallow[reco]>=2,<3", "marshmallow>=3,<4"]
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ test:
 
 pyenv:
 	echo marshmallow_recipe > .python-version && pyenv install -s 3.10.2 && pyenv virtualenv -f 3.10.2 marshmallow_recipe
+
+pyenv-delete:
+	pyenv virtualenv-delete -f marshmallow_recipe

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -270,8 +270,16 @@ else:
             return {}
         return dict(dump_to=name, load_from=name)
 
+    def _custom_datetime_serialize(dt: datetime.datetime, *_: Any, **__: Any) -> Any:
+        return dt.isoformat()
+
     class DateTimeFieldV2(m.fields.DateTime):
-        def _deserialize(self, value: Any, attr: Any, data: Any) -> Any:
+        DATEFORMAT_SERIALIZATION_FUNCS = {
+            **m.fields.DateTime.DATEFORMAT_SERIALIZATION_FUNCS,  # type: ignore
+            "iso": _custom_datetime_serialize,
+        }
+
+        def _deserialize(self, value: Any, attr: Any, data: Any, **_: Any) -> Any:
             result = super()._deserialize(value, attr, data)
             if result.tzinfo is None:
                 return result

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -246,6 +246,8 @@ def dict_field(
     )
 
 
+DateTimeField: Type[m.fields.DateTime]
+
 if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     def data_key(name: str | None) -> dict[str, Any]:
@@ -253,12 +255,14 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
             return {}
         return dict(data_key=name)
 
-    class DateTimeField(m.fields.DateTime):
+    class DateTimeFieldV3(m.fields.DateTime):
         def _deserialize(self, value: Any, attr: Any, data: Any, **kwargs: Any) -> Any:
             result = super()._deserialize(value, attr, data)
             if result.tzinfo is None:
                 return result
             return result.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+
+    DateTimeField = DateTimeFieldV3
 else:
 
     def data_key(name: str | None) -> dict[str, Any]:
@@ -266,10 +270,11 @@ else:
             return {}
         return dict(dump_to=name, load_from=name)
 
-
-    class DateTimeField(m.fields.DateTime):
+    class DateTimeFieldV2(m.fields.DateTime):
         def _deserialize(self, value: Any, attr: Any, data: Any) -> Any:
             result = super()._deserialize(value, attr, data)
             if result.tzinfo is None:
                 return result
             return result.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+
+    DateTimeField = DateTimeFieldV2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ isort==5.10.1
 flake8==4.0.1
 black==22.1.0
 mypy==0.931
-marshmallow>2,<4
+marshmallow>=2,<4
 typing_inspect>=0.7.1
 
 setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ isort==5.10.1
 flake8==4.0.1
 black==22.1.0
 mypy==0.931
-marshmallow>=2,<3
+marshmallow>=2,<4
 typing_inspect>=0.7.1
 
 setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ isort==5.10.1
 flake8==4.0.1
 black==22.1.0
 mypy==0.931
-marshmallow>=2,<4
+marshmallow>=2,<3
 typing_inspect>=0.7.1
 
 setuptools

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -10,7 +10,7 @@ import marshmallow as m
 import pytest
 
 import marshmallow_recipe as mr
-from marshmallow_recipe.fields import DateTimeField
+import marshmallow_recipe.fields as mr_fields
 
 _MARSHMALLOW_VERSION_MAJOR = int(m.__version__.split(".")[0])
 
@@ -158,31 +158,31 @@ EMPTY_SCHEMA = m.Schema()
             m.fields.Decimal(allow_none=True, missing=None, default=None, places=4, as_string=False, **data_key("i")),
         ),
         # simple types: datetime
-        (datetime.datetime, {}, DateTimeField(required=True)),
+        (datetime.datetime, {}, mr_fields.DateTimeField(required=True)),
         (
             Optional[datetime.datetime],
             {},
-            DateTimeField(allow_none=True, missing=None, default=None),
+            mr_fields.DateTimeField(allow_none=True, missing=None, default=None),
         ),
         (
             datetime.datetime | None,
             {},
-            DateTimeField(allow_none=True, missing=None, default=None),
+            mr_fields.DateTimeField(allow_none=True, missing=None, default=None),
         ),
         (
             datetime.datetime,
             mr.metadata(name="i"),
-            DateTimeField(required=True, **data_key("i")),
+            mr_fields.DateTimeField(required=True, **data_key("i")),
         ),
         (
             Optional[datetime.datetime],
             mr.metadata(name="i"),
-            DateTimeField(allow_none=True, missing=None, default=None, **data_key("i")),
+            mr_fields.DateTimeField(allow_none=True, missing=None, default=None, **data_key("i")),
         ),
         (
             datetime.datetime | None,
             mr.metadata(name="i"),
-            DateTimeField(allow_none=True, missing=None, default=None, **data_key("i")),
+            mr_fields.DateTimeField(allow_none=True, missing=None, default=None, **data_key("i")),
         ),
         # simple types: date
         (datetime.date, {}, m.fields.Date(required=True)),

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -10,6 +10,7 @@ import marshmallow as m
 import pytest
 
 import marshmallow_recipe as mr
+from marshmallow_recipe.fields import DateTimeField
 
 _MARSHMALLOW_VERSION_MAJOR = int(m.__version__.split(".")[0])
 
@@ -157,31 +158,31 @@ EMPTY_SCHEMA = m.Schema()
             m.fields.Decimal(allow_none=True, missing=None, default=None, places=4, as_string=False, **data_key("i")),
         ),
         # simple types: datetime
-        (datetime.datetime, {}, m.fields.DateTime(required=True)),
+        (datetime.datetime, {}, DateTimeField(required=True)),
         (
             Optional[datetime.datetime],
             {},
-            m.fields.DateTime(allow_none=True, missing=None, default=None),
+            DateTimeField(allow_none=True, missing=None, default=None),
         ),
         (
             datetime.datetime | None,
             {},
-            m.fields.DateTime(allow_none=True, missing=None, default=None),
+            DateTimeField(allow_none=True, missing=None, default=None),
         ),
         (
             datetime.datetime,
             mr.metadata(name="i"),
-            m.fields.DateTime(required=True, **data_key("i")),
+            DateTimeField(required=True, **data_key("i")),
         ),
         (
             Optional[datetime.datetime],
             mr.metadata(name="i"),
-            m.fields.DateTime(allow_none=True, missing=None, default=None, **data_key("i")),
+            DateTimeField(allow_none=True, missing=None, default=None, **data_key("i")),
         ),
         (
             datetime.datetime | None,
             mr.metadata(name="i"),
-            m.fields.DateTime(allow_none=True, missing=None, default=None, **data_key("i")),
+            DateTimeField(allow_none=True, missing=None, default=None, **data_key("i")),
         ),
         # simple types: date
         (datetime.date, {}, m.fields.Date(required=True)),

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,7 +2,7 @@ import dataclasses
 import datetime
 import decimal
 import uuid
-from typing import Any
+from typing import Any, cast
 
 import marshmallow_recipe as mr
 
@@ -22,6 +22,8 @@ def test_simple_types() -> None:
         optional_float_field: float | None
         uuid_field: uuid.UUID
         optional_uuid_field: uuid.UUID | None
+        datetime_tz_utc_field: datetime.datetime
+        optional_datetime_tz_utc_field: datetime.datetime | None
         datetime_field: datetime.datetime
         optional_datetime_field: datetime.datetime | None
         date_field: datetime.date
@@ -42,8 +44,10 @@ def test_simple_types() -> None:
         optional_float_field=42.0,
         uuid_field="15f75b02-1c34-46a2-92a5-18363aadea05",
         optional_uuid_field="15f75b02-1c34-46a2-92a5-18363aadea05",
-        datetime_field="2022-02-20T11:33:48.607289+00:00",
-        optional_datetime_field="2022-02-20T11:33:48.607289+00:00",
+        datetime_tz_utc_field="2022-02-20T11:33:48.607289+00:00",
+        optional_datetime_tz_utc_field="2022-02-20T11:33:48.607289+00:00",
+        datetime_field="2022-02-20T11:33:48.607289",
+        optional_datetime_field="2022-02-20T11:33:48.607289",
         date_field="2022-02-20",
         optional_date_field="2022-02-20",
         dict_field=dict(key="value"),
@@ -66,6 +70,8 @@ def test_simple_types() -> None:
         optional_float_field=42.0,
         uuid_field=uuid.UUID("15f75b02-1c34-46a2-92a5-18363aadea05"),
         optional_uuid_field=uuid.UUID("15f75b02-1c34-46a2-92a5-18363aadea05"),
+        datetime_tz_utc_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289),
+        optional_datetime_tz_utc_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289),
         datetime_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289),
         optional_datetime_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289),
         date_field=datetime.date(2022, 2, 20),
@@ -73,7 +79,11 @@ def test_simple_types() -> None:
         dict_field=dict(key="value"),
         optional_dict_field=dict(key="value"),
     )
-    assert dumped == raw
+    assert dumped == {
+        **raw,
+        "datetime_tz_utc_field": cast(Any, "2022-02-20T11:33:48.607289"),
+        "optional_datetime_tz_utc_field": cast(Any, "2022-02-20T11:33:48.607289"),
+    }
     assert mr.schema(SimpleTypesContainers) is mr.schema(SimpleTypesContainers)
 
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,7 +2,9 @@ import dataclasses
 import datetime
 import decimal
 import uuid
-from typing import Any, cast
+from typing import Any
+
+import pytest
 
 import marshmallow_recipe as mr
 
@@ -22,8 +24,6 @@ def test_simple_types() -> None:
         optional_float_field: float | None
         uuid_field: uuid.UUID
         optional_uuid_field: uuid.UUID | None
-        datetime_tz_utc_field: datetime.datetime
-        optional_datetime_tz_utc_field: datetime.datetime | None
         datetime_field: datetime.datetime
         optional_datetime_field: datetime.datetime | None
         date_field: datetime.date
@@ -44,10 +44,8 @@ def test_simple_types() -> None:
         optional_float_field=42.0,
         uuid_field="15f75b02-1c34-46a2-92a5-18363aadea05",
         optional_uuid_field="15f75b02-1c34-46a2-92a5-18363aadea05",
-        datetime_tz_utc_field="2022-02-20T11:33:48.607289+00:00",
-        optional_datetime_tz_utc_field="2022-02-20T11:33:48.607289+00:00",
-        datetime_field="2022-02-20T11:33:48.607289",
-        optional_datetime_field="2022-02-20T11:33:48.607289",
+        datetime_field="2022-02-20T11:33:48.607289+00:00",
+        optional_datetime_field="2022-02-20T11:33:48.607289+00:00",
         date_field="2022-02-20",
         optional_date_field="2022-02-20",
         dict_field=dict(key="value"),
@@ -70,20 +68,14 @@ def test_simple_types() -> None:
         optional_float_field=42.0,
         uuid_field=uuid.UUID("15f75b02-1c34-46a2-92a5-18363aadea05"),
         optional_uuid_field=uuid.UUID("15f75b02-1c34-46a2-92a5-18363aadea05"),
-        datetime_tz_utc_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289),
-        optional_datetime_tz_utc_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289),
-        datetime_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289),
-        optional_datetime_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289),
+        datetime_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289, datetime.timezone.utc),
+        optional_datetime_field=datetime.datetime(2022, 2, 20, 11, 33, 48, 607289, datetime.timezone.utc),
         date_field=datetime.date(2022, 2, 20),
         optional_date_field=datetime.date(2022, 2, 20),
         dict_field=dict(key="value"),
         optional_dict_field=dict(key="value"),
     )
-    assert dumped == {
-        **raw,
-        "datetime_tz_utc_field": cast(Any, "2022-02-20T11:33:48.607289"),
-        "optional_datetime_tz_utc_field": cast(Any, "2022-02-20T11:33:48.607289"),
-    }
+    assert dumped == raw
     assert mr.schema(SimpleTypesContainers) is mr.schema(SimpleTypesContainers)
 
 
@@ -134,3 +126,35 @@ def test_unknown_field() -> None:
     assert dumped == dict(bool_field=True)
 
     assert mr.schema(BoolContainer) is mr.schema(BoolContainer)
+
+
+@pytest.mark.parametrize(
+    "raw, dt",
+    [
+        ("2022-02-20T11:33:48.607289+00:00", datetime.datetime(2022, 2, 20, 11, 33, 48, 607289, datetime.timezone.utc)),
+        ("2022-02-20T11:33:48.607289", datetime.datetime(2022, 2, 20, 11, 33, 48, 607289, datetime.timezone.utc)),
+    ],
+)
+def test_datetime_field_load(raw: str, dt: datetime.datetime) -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class DateTimeContainer:
+        datetime_field: datetime.datetime
+
+    loaded = mr.load(DateTimeContainer, dict(datetime_field=raw))
+    assert loaded == DateTimeContainer(datetime_field=dt)
+
+
+@pytest.mark.parametrize(
+    "dt, raw",
+    [
+        (datetime.datetime(2022, 2, 20, 11, 33, 48, 607289, datetime.timezone.utc), "2022-02-20T11:33:48.607289+00:00"),
+        (datetime.datetime(2022, 2, 20, 11, 33, 48, 607289, None), "2022-02-20T11:33:48.607289+00:00"),
+    ],
+)
+def test_datetime_field_dump(dt: datetime.datetime, raw: str) -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class DateTimeContainer:
+        datetime_field: datetime.datetime
+
+    dumped = mr.dump(DateTimeContainer(datetime_field=dt))
+    assert dumped == dict(datetime_field=raw)


### PR DESCRIPTION
PR aims to unify work with datetime:
1. If a timezone is not specified or specified as UTC(00:00) we should deserialize it as a datetime with UTC time zone.
2. If a timezone is not specified or specified as UTC(00:00) we should serialize it as a datetime with UTC time zone.
3. If a timezone is specified and it is not UTC(00:00) we should convert the timezone to UTC on deserialize.